### PR TITLE
Add occupancy prediction with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
 # Demo1234
-Just to show that Codex can one-shot
+
+This project demonstrates forecasting hotel occupancy using three approaches:
+ARIMA, linear regression, and a neural network. The dataset spans 2024–2026 and
+is stored in `hotel_factors_three_years.csv`.
+
+## Usage
+
+Install dependencies and run the predictor:
+
+```bash
+pip install -r requirements.txt  # or manually install pandas, scikit-learn, matplotlib, statsmodels
+python hotel_predictor.py
+```
+
+The script prints mean absolute error for each method and saves a plot named
+`occupancy_predictions.png` showing actual vs predicted occupancy for 2026.
+
+## Tests
+
+Tests verify that all models achieve reasonable accuracy. Run with:
+
+```bash
+pytest -v
+```

--- a/hotel_predictor.py
+++ b/hotel_predictor.py
@@ -1,0 +1,108 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+from statsmodels.tsa.arima.model import ARIMA
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_absolute_error
+from sklearn.neural_network import MLPRegressor
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+DATA_FILE = 'hotel_factors_three_years.csv'
+FEATURES = [
+    'Day_of_Year',
+    'Domestic_Guests',
+    'Foreign_Guests',
+    'Flight_Price',
+    'Reviews',
+    'Event_Flag',
+    'Season_Flag',
+    'Availability',
+    'Hotel_Price',
+    'Competing_Hotels_Availability'
+]
+
+
+def load_data(path: str = DATA_FILE) -> pd.DataFrame:
+    """Load dataset from CSV."""
+    return pd.read_csv(path)
+
+
+def split_data(df: pd.DataFrame):
+    train = df[df['Year'] < 2026].reset_index(drop=True)
+    test = df[df['Year'] == 2026].reset_index(drop=True)
+    return train, test
+
+
+def predict_arima(train: pd.DataFrame, test: pd.DataFrame):
+    model = ARIMA(train['Occupancy'], order=(1, 0, 1)).fit()
+    forecast = model.forecast(steps=len(test))
+    mae = mean_absolute_error(test['Occupancy'], forecast)
+    return forecast, mae
+
+
+def predict_regression(train: pd.DataFrame, test: pd.DataFrame):
+    X_train, y_train = train[FEATURES], train['Occupancy']
+    X_test, y_test = test[FEATURES], test['Occupancy']
+    model = LinearRegression().fit(X_train, y_train)
+    forecast = model.predict(X_test)
+    mae = mean_absolute_error(y_test, forecast)
+    return forecast, mae
+
+
+def predict_nn(train: pd.DataFrame, test: pd.DataFrame):
+    X_train, y_train = train[FEATURES], train['Occupancy']
+    X_test, y_test = test[FEATURES], test['Occupancy']
+    model = Pipeline([
+        ('scaler', StandardScaler()),
+        ('mlp', MLPRegressor(hidden_layer_sizes=(50,), max_iter=500, random_state=42))
+    ])
+    model.fit(X_train, y_train)
+    forecast = model.predict(X_test)
+    mae = mean_absolute_error(y_test, forecast)
+    return forecast, mae
+
+
+def plot_results(test: pd.DataFrame, preds: dict):
+    days = range(len(test))
+    plt.figure(figsize=(10, 6))
+    plt.plot(days, test['Occupancy'], label='Actual')
+    for name, values in preds.items():
+        plt.plot(days, values, label=name)
+    plt.xlabel('Day of 2026')
+    plt.ylabel('Occupancy')
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig('occupancy_predictions.png')
+
+
+def main():
+    df = load_data()
+    train, test = split_data(df)
+    arima_pred, arima_mae = predict_arima(train, test)
+    reg_pred, reg_mae = predict_regression(train, test)
+    nn_pred, nn_mae = predict_nn(train, test)
+
+    print(f'ARIMA MAE: {arima_mae:.2f}')
+    print(f'Regression MAE: {reg_mae:.2f}')
+    print(f'Neural Net MAE: {nn_mae:.2f}')
+
+    plot_results(test, {
+        'ARIMA': arima_pred,
+        'Regression': reg_pred,
+        'NeuralNet': nn_pred
+    })
+
+    return {
+        'arima_mae': arima_mae,
+        'regression_mae': reg_mae,
+        'nn_mae': nn_mae,
+        'predictions': {
+            'arima': arima_pred,
+            'regression': reg_pred,
+            'nn': nn_pred
+        }
+    }
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+matplotlib
+scikit-learn
+statsmodels

--- a/test_predictor.py
+++ b/test_predictor.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from hotel_predictor import load_data, split_data, predict_arima, predict_regression, predict_nn
+
+def test_arima_mae():
+    df = load_data()
+    train, test = split_data(df)
+    _, mae = predict_arima(train, test)
+    assert mae < 5
+
+def test_regression_mae():
+    df = load_data()
+    train, test = split_data(df)
+    _, mae = predict_regression(train, test)
+    assert mae < 2
+
+def test_nn_mae():
+    df = load_data()
+    train, test = split_data(df)
+    _, mae = predict_nn(train, test)
+    assert mae < 5


### PR DESCRIPTION
## Summary
- implement `hotel_predictor.py` with ARIMA, regression and neural net forecasts
- add tests ensuring each model has a reasonable MAE
- document usage in README
- add requirements list

## Testing
- `pytest -q`
- `python hotel_predictor.py`

------
https://chatgpt.com/codex/tasks/task_e_6840a7f0df90832ba099681b3804cd8d